### PR TITLE
[feat]#39- 시험 데이터 등록부터 -> 입장 -> 응시 제출 / 시험 제출 까지 백엔드 API 개발

### DIFF
--- a/src/main/java/com/nlb/controller/ExamController.java
+++ b/src/main/java/com/nlb/controller/ExamController.java
@@ -1,70 +1,8 @@
 package com.nlb.controller;
 
 
-import com.mongodb.client.MongoClient;
-import com.nlb.dto.response.CMResDTO;
-import com.nlb.exception.ErrorCode;
-import com.nlb.service.ExamService;
-import com.nlb.vo.ExamMongoVO;
-import com.nlb.vo.QuestionVO;
-import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 
 @Controller
-@RequestMapping("/api/exam")
 public class ExamController {
-
-  @Autowired
-  private ExamService examService;
-  @Autowired
-  private MongoClient mongoClient;
-  @Autowired
-  private MongoTemplate mongoTemplate;
-
-  @PostMapping("/init")
-  public ResponseEntity<CMResDTO<String>> createExam(
-      @RequestBody ExamMongoVO examMongoVO) {
-
-    int examId = examService.createExam(examMongoVO);
-    return new ResponseEntity<>(CMResDTO.successDataRes("시험 등록 성공, " + examId), HttpStatus.OK);
-  }
-
-  @PutMapping("/init/{examId}")
-  public ResponseEntity<CMResDTO<String>> updateExam(
-      @PathVariable int examId,
-      @RequestBody ExamMongoVO examMongoVO) {
-
-    boolean success = examService.updateExam(examId, examMongoVO);
-    if (success) {
-      return new ResponseEntity<>(CMResDTO.successDataRes("시험 수정 성공, " + examId), HttpStatus.OK);
-    } else {
-      return new ResponseEntity<>(CMResDTO.errorRes(ErrorCode.BAD_REQUEST), HttpStatus.BAD_REQUEST);
-    }
-  }
-
-  @PutMapping("/{examId}/questions")
-  public ResponseEntity<CMResDTO<String>> updateQuestion(
-      @PathVariable int examId,
-      @RequestBody List<QuestionVO> questions) {
-
-    boolean success = examService.updateQuestions(examId, questions);
-    if (success) {
-      return new ResponseEntity<>(CMResDTO.successDataRes("문제 등록 성공, "), HttpStatus.OK);
-    } else {
-      return new ResponseEntity<>(CMResDTO.errorRes(ErrorCode.BAD_REQUEST), HttpStatus.BAD_REQUEST);
-    }
-  }
-
-
 }
-//

--- a/src/main/java/com/nlb/controller/ExamRestController.java
+++ b/src/main/java/com/nlb/controller/ExamRestController.java
@@ -1,55 +1,120 @@
 package com.nlb.controller;
 
 
+import com.nlb.dto.request.ExamReqDTO;
 import com.nlb.dto.response.CMResDTO;
+import com.nlb.exception.ErrorCode;
 import com.nlb.service.ExamService;
 import com.nlb.vo.ExamVO;
+import com.nlb.vo.QuestionVO;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/api/exams")
 public class ExamRestController {
 
-    @Autowired
-    private ExamService examService;
+  @Autowired
+  private ExamService examService;
 
-    // 정렬기능(제목, 생성일, 응시자수, 카테고리) & 필터기능(카테고리)
-    @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
-    public ResponseEntity<CMResDTO<List<ExamVO>>> examsOfConstructor(
-            @PathVariable("userId") int userId,
-            @RequestParam(value = "sortBy", defaultValue = "createAt") String sortBy, //createAt, title, examineeCount, category
-            @RequestParam(value = "order", defaultValue = "asc") String order,
-            @RequestParam(value = "category", required = false) String category) {
+  // 정렬기능(제목, 생성일, 응시자수, 카테고리) & 필터기능(카테고리)
+  @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
+  public ResponseEntity<CMResDTO<List<ExamVO>>> examsOfConstructor(
+      @PathVariable("userId") int userId,
+      @RequestParam(value = "sortBy", defaultValue = "createAt") String sortBy,
+      //createAt, title, examineeCount, category
+      @RequestParam(value = "order", defaultValue = "asc") String order,
+      @RequestParam(value = "category", required = false) String category) {
 
-        List<ExamVO> examVOList = examService.getExamList(userId, sortBy, order, category);
+    List<ExamVO> examVOList = examService.getExamList(userId, sortBy, order, category);
 
-        return new ResponseEntity<>(CMResDTO.successDataRes(examVOList), HttpStatus.OK);
+    return new ResponseEntity<>(CMResDTO.successDataRes(examVOList), HttpStatus.OK);
+  }
+
+  // 시험 상태 변경 (시작전, 진행중, 비활성화)
+  @RequestMapping(value = "/{examId}/status", method = RequestMethod.PUT)
+  public ResponseEntity<CMResDTO<String>> setExamStatus(@PathVariable("examId") int examId,
+      @RequestParam("status") String status) {
+
+    if (!status.equals("not_stated") && !status.equals("on_going") && !status.equals("closed")) {
+      throw new IllegalArgumentException("유효하지 않은 파라미터입니다: " + status);
     }
-    // 시험 상태 변경 (시작전, 진행중, 비활성화)
-    @RequestMapping(value = "/{examId}/status", method = RequestMethod.PUT)
-    public ResponseEntity<CMResDTO<String>> setExamStatus(@PathVariable("examId") int examId,
-                                                          @RequestParam("status") String status) {
+    int rows = examService.setExamStatus(examId, status);
 
-        if (!status.equals("not_stated") && !status.equals("on_going") && !status.equals("closed")) {
-            throw new IllegalArgumentException("유효하지 않은 파라미터입니다: " + status);
-        }
-        int rows = examService.setExamStatus(examId, status);
+    return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
+  }
 
-        return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
+  //시험 삭제
+  @RequestMapping(value = "/{examId}", method = RequestMethod.DELETE)
+  public ResponseEntity<CMResDTO<String>> deleteExam(@PathVariable("examId") int examId) {
+
+    examService.deleteExam(examId);
+
+    return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
+  }
+
+
+  // 시험 초기 데이터 입력
+  @PostMapping("/init")
+  public ResponseEntity<CMResDTO<String>> createExam(
+      @RequestBody ExamReqDTO examReqDTO) {
+
+    int examId = examService.createExam(examReqDTO);
+    return new ResponseEntity<>(CMResDTO.successDataRes("시험 등록 성공, " + examId), HttpStatus.OK);
+  }
+
+  // 시험 초기 데이터 수정
+  @PutMapping("/init/{examId}")
+  public ResponseEntity<CMResDTO<String>> updateExam(
+      @PathVariable int examId,
+      @RequestBody ExamReqDTO examReqDTO) {
+
+    boolean success = examService.updateExam(examId, examReqDTO);
+    if (success) {
+      return new ResponseEntity<>(CMResDTO.successDataRes("시험 수정 성공, " + examId), HttpStatus.OK);
+    } else {
+      return new ResponseEntity<>(CMResDTO.errorRes(ErrorCode.BAD_REQUEST), HttpStatus.BAD_REQUEST);
     }
+  }
 
-    //시험 삭제
-    @RequestMapping(value = "/{examId}", method = RequestMethod.DELETE)
-    public ResponseEntity<CMResDTO<String>> deleteExam(@PathVariable("examId") int examId) {
+  // 문제 데이터 입력
+  @PutMapping("/{examId}/questions")
+  public ResponseEntity<CMResDTO<String>> updateQuestion(
+      @PathVariable int examId,
+      @RequestBody List<QuestionVO> questions) {
 
-        examService.deleteExam(examId);
+    int updatedCount = examService.updateQuestions(examId, questions);
 
-        return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
-    }
+    return new ResponseEntity<>(CMResDTO.successDataRes("문제 등록 완료, 업데이트된 개수: " + updatedCount),
+        HttpStatus.OK);
+  }
+
+  // 전체 문제 조회 (시험 아이디로)
+  @GetMapping("/{examId}/questions")
+  public ResponseEntity<CMResDTO<List<QuestionVO>>> getExamQuestions(
+      @PathVariable("examId") int examId) {
+    List<QuestionVO> questions = examService.getExamQuestions(examId);
+    return new ResponseEntity<>(CMResDTO.successDataRes(questions), HttpStatus.OK);
+  }
+
+
+  //시험 상태 확인
+  @GetMapping("/{examId}/status")
+  public ResponseEntity<CMResDTO<String>> getExamStatus(@PathVariable("examId") int examId) {
+    String status = examService.getExamStatus(examId);
+    return new ResponseEntity<>(CMResDTO.successDataRes(status), HttpStatus.OK);
+  }
+
+
 }

--- a/src/main/java/com/nlb/controller/ExamResultRestController.java
+++ b/src/main/java/com/nlb/controller/ExamResultRestController.java
@@ -1,73 +1,156 @@
 package com.nlb.controller;
 
 
+import com.nlb.dto.request.ExamResultReqDTO;
 import com.nlb.dto.response.CMResDTO;
+import com.nlb.dto.response.ExamDataResDTO;
+import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
 import com.nlb.service.ExamResultService;
-import com.nlb.service.NlbUserService;
+import com.nlb.vo.AnswerVO;
 import com.nlb.vo.ExamResultVO;
-import com.nlb.vo.ExamVO;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/api/exams/results")
 public class ExamResultRestController {
 
-    @Autowired
-    private ExamResultService examResultService;
+  @Autowired
+  private ExamResultService examResultService;
 
 
-    // 내가 만든 시험의 응시 내역 조회
-    // 정렬기능(점수, 응시일) & 필터기능(검토상태)
-    @RequestMapping(value = "/{examId}", method = RequestMethod.GET)
-    public ResponseEntity<CMResDTO<List<ExamResultVO>>> examResults(
-            @PathVariable("examId") int examId,
-            @RequestParam(value = "sortBy", defaultValue = "submittedAt") String sortBy, //score, submittedAt
-            @RequestParam(value = "order", defaultValue = "asc") String order,
-            @RequestParam(value = "isReviewed", required = false) Boolean isReviewed) {
+  // 내가 만든 시험의 응시 내역 조회
+  // 정렬기능(점수, 응시일) & 필터기능(검토상태)
+  @RequestMapping(value = "/{examId}", method = RequestMethod.GET)
+  public ResponseEntity<CMResDTO<List<ExamResultVO>>> examResults(
+      @PathVariable("examId") int examId,
+      @RequestParam(value = "sortBy", defaultValue = "submittedAt") String sortBy,
+      //score, submittedAt
+      @RequestParam(value = "order", defaultValue = "asc") String order,
+      @RequestParam(value = "isReviewed", required = false) Boolean isReviewed) {
 
-        List<ExamResultVO> examResultVOList = examResultService.getExamResultList(examId, sortBy, order, isReviewed);
+    List<ExamResultVO> examResultVOList = examResultService.getExamResultList(examId, sortBy, order,
+        isReviewed);
 
-        return new ResponseEntity<>(CMResDTO.successDataRes(examResultVOList), HttpStatus.OK);
-    }
+    return new ResponseEntity<>(CMResDTO.successDataRes(examResultVOList), HttpStatus.OK);
+  }
 
-    // 시험 결과 검토 상태 변경
-    @RequestMapping(value = "/{resultId}/status", method = RequestMethod.PUT)
-    public ResponseEntity<CMResDTO<String>> setExamResultStatus(@PathVariable("resultId") int resultId,
-                                                          @RequestParam("isReviewed") Boolean isReviewed) {
+  // 시험 결과 검토 상태 변경
+  @RequestMapping(value = "/{resultId}/status", method = RequestMethod.PUT)
+  public ResponseEntity<CMResDTO<String>> setExamResultStatus(
+      @PathVariable("resultId") int resultId,
+      @RequestParam("isReviewed") Boolean isReviewed) {
 
-        int rows = examResultService.setExamResultStatus(resultId, isReviewed);
+    int rows = examResultService.setExamResultStatus(resultId, isReviewed);
 
-        return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
-    }
+    return new ResponseEntity<>(CMResDTO.successNoRes(), HttpStatus.OK);
+  }
 
 
-    // 내가 본 시험 결과들 조회
-    // 정렬기능(점수, 응시일) & 필터기능(검토상태)
-    @RequestMapping(value = "/user/{userId}", method = RequestMethod.GET)
-    public ResponseEntity<CMResDTO<List<ExamResultVO>>> examResultsOfUser(
-            @PathVariable("userId") int userId,
-            @RequestParam(value = "sortBy", defaultValue = "submittedAt") String sortBy, //score, submittedAt, category
-            @RequestParam(value = "order", defaultValue = "asc") String order,
-            @RequestParam(value = "isReviewed", required = false) Boolean isReviewed) {
+  // 내가 본 시험 결과들 조회
+  // 정렬기능(점수, 응시일) & 필터기능(검토상태)
+  @RequestMapping(value = "/user/{userId}", method = RequestMethod.GET)
+  public ResponseEntity<CMResDTO<List<ExamResultVO>>> examResultsOfUser(
+      @PathVariable("userId") int userId,
+      @RequestParam(value = "sortBy", defaultValue = "submittedAt") String sortBy,
+      //score, submittedAt, category
+      @RequestParam(value = "order", defaultValue = "asc") String order,
+      @RequestParam(value = "isReviewed", required = false) Boolean isReviewed) {
 
-        List<ExamResultVO> examResultVOList = examResultService.getExamResultListOfUser(userId, sortBy, order, isReviewed);
+    List<ExamResultVO> examResultVOList = examResultService.getExamResultListOfUser(userId, sortBy,
+        order, isReviewed);
 
-        return new ResponseEntity<>(CMResDTO.successDataRes(examResultVOList), HttpStatus.OK);
-    }
+    return new ResponseEntity<>(CMResDTO.successDataRes(examResultVOList), HttpStatus.OK);
+  }
 
-    // 시험 결과 카드 데이터 조회
+  // 시험 결과 카드 데이터 조회
 
-    @RequestMapping(value = "/{resultId}/card", method = RequestMethod.GET)
-    public ResponseEntity<CMResDTO<ExamResultCardDTO>> examResultCard(@PathVariable("resultId") int resultId){
-        ExamResultCardDTO examResultCardDTO = examResultService.getExamResultAndExam(resultId);
-        return new ResponseEntity<>(CMResDTO.successDataRes(examResultCardDTO), HttpStatus.OK);
-    }
+  @RequestMapping(value = "/{resultId}/card", method = RequestMethod.GET)
+  public ResponseEntity<CMResDTO<ExamResultCardDTO>> examResultCard(
+      @PathVariable("resultId") int resultId) {
+    ExamResultCardDTO examResultCardDTO = examResultService.getExamResultAndExam(resultId);
+    return new ResponseEntity<>(CMResDTO.successDataRes(examResultCardDTO), HttpStatus.OK);
+  }
+
+
+  // 시험 제출
+  @PostMapping("/{resultId}/submit")
+  public ResponseEntity<CMResDTO<List<AnswerVO>>> submitExam(
+      @PathVariable int resultId,
+      @RequestBody ExamResultReqDTO examResultReqDTO) {
+
+    //todo 세션으로 아이디 가져오기
+    int examineeId = 1;
+    List<AnswerVO> savedAnswers = examResultService.submitExam(examineeId, examResultReqDTO);
+
+    return new ResponseEntity<>(CMResDTO.successDataRes(savedAnswers), HttpStatus.OK);
+  }
+
+
+  //시험 응답 저장
+  @PostMapping("/{resultId}/answers")
+  public ResponseEntity<CMResDTO<String>> saveExamAnswers(
+      @PathVariable int resultId,
+      @RequestBody ExamResultReqDTO examResultReqDTO) {
+
+    //todo 세션으로 아이디 가져오기
+    int examineeId = 1;
+    int summitCount = examResultService.saveExamAnswers(examineeId, examResultReqDTO);
+
+    return new ResponseEntity<>(CMResDTO.successDataRes("응답 저장 완료 개수" + summitCount),
+        HttpStatus.OK);
+  }
+
+  //시험 입장
+  @PostMapping("/{examId}/join")
+  public ResponseEntity<CMResDTO<ExamJoinResDTO>> joinExam(
+      @RequestParam String examCode,
+      @RequestParam String entreeCode) {
+    //Integer examineeId = (Integer) session.getAttribute("userId");
+    //todo 로그인 개발되면 세션으로 변경
+    int examineeId = 1;
+    ExamJoinResDTO response = examResultService.joinExam(examCode, examineeId, entreeCode);
+
+    return new ResponseEntity<>(CMResDTO.successDataRes(response), HttpStatus.OK);
+  }
+
+  @GetMapping("/{examId}/{examineeId}")
+  public ResponseEntity<CMResDTO<Map<String, Object>>> getExamData(
+      @PathVariable("examId") int examId,
+      @PathVariable("examineeId") int examineeId
+  ) {
+    Map<String, Object> resultData = examResultService.getExamResultData(examId, examineeId);
+    return new ResponseEntity<>(CMResDTO.successDataRes(resultData), HttpStatus.OK);
+  }
+
+  //시험
+  @GetMapping("/{examId}/exam-data")
+  public ResponseEntity<CMResDTO<ExamDataResDTO>> getExamDataForUser(
+      @PathVariable("examId") int examId,
+      HttpSession session) {
+
+    //todo 로그인 개발되면 사용
+    //Integer examineeId = (Integer) session.getAttribute("userId");
+
+    int examineeId = 1;
+
+    ExamDataResDTO examData = examResultService.getExamData(examId, examineeId);
+    return new ResponseEntity<>(CMResDTO.successDataRes(examData), HttpStatus.OK);
+  }
+
 
 }
+

--- a/src/main/java/com/nlb/controller/NlbUserController.java
+++ b/src/main/java/com/nlb/controller/NlbUserController.java
@@ -1,8 +1,19 @@
 package com.nlb.controller;
 
 
+import javax.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Controller
 public class NlbUserController {
+
+  @PostMapping("/login")
+  public ResponseEntity<String> login(HttpSession session) {
+    session.setAttribute("userId", 1); // 세션에 userId 저장
+    return new ResponseEntity<>("Login successful", HttpStatus.OK);
+  }
+
 }

--- a/src/main/java/com/nlb/dto/request/ExamReqDTO.java
+++ b/src/main/java/com/nlb/dto/request/ExamReqDTO.java
@@ -1,0 +1,16 @@
+package com.nlb.dto.request;
+
+import com.nlb.vo.ExamMongoVO;
+import com.nlb.vo.ExamVO;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExamReqDTO {
+
+  private ExamVO examVO;
+  private ExamMongoVO examMongoVO;
+}

--- a/src/main/java/com/nlb/dto/request/ExamResultReqDTO.java
+++ b/src/main/java/com/nlb/dto/request/ExamResultReqDTO.java
@@ -1,0 +1,16 @@
+package com.nlb.dto.request;
+
+import com.nlb.vo.ExamResultMongoVO;
+import com.nlb.vo.ExamResultVO;
+import lombok.*;
+
+@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExamResultReqDTO {
+
+    private ExamResultVO examResultVO;
+    private ExamResultMongoVO examResultMongoVO;
+}

--- a/src/main/java/com/nlb/dto/response/ExamDataResDTO.java
+++ b/src/main/java/com/nlb/dto/response/ExamDataResDTO.java
@@ -1,0 +1,22 @@
+package com.nlb.dto.response;
+
+import com.nlb.vo.AnswerVO;
+import com.nlb.vo.QuestionVO;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExamDataResDTO {
+
+
+  private int examId;
+  private int resultId;
+  private int examineeId;
+  private List<QuestionVO> questions;
+  private List<AnswerVO> submittedAnswers;
+
+}

--- a/src/main/java/com/nlb/dto/response/ExamJoinResDTO.java
+++ b/src/main/java/com/nlb/dto/response/ExamJoinResDTO.java
@@ -1,0 +1,17 @@
+package com.nlb.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExamJoinResDTO {
+
+  private int examId;
+  private int resultId;
+  private String examCode;
+  private int examineeId;
+  private String redirectUrl;
+}

--- a/src/main/java/com/nlb/exception/AuthenticationException.java
+++ b/src/main/java/com/nlb/exception/AuthenticationException.java
@@ -1,0 +1,11 @@
+package com.nlb.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthenticationException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+}

--- a/src/main/java/com/nlb/exception/CustomAccessDeniedException.java
+++ b/src/main/java/com/nlb/exception/CustomAccessDeniedException.java
@@ -1,0 +1,16 @@
+package com.nlb.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomAccessDeniedException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public CustomAccessDeniedException(String message) {
+    super(message);
+    this.errorCode = ErrorCode.FORBIDDEN;
+  }
+}

--- a/src/main/java/com/nlb/exception/DuplicatedQuestionException.java
+++ b/src/main/java/com/nlb/exception/DuplicatedQuestionException.java
@@ -1,0 +1,16 @@
+package com.nlb.exception;
+
+import lombok.Data;
+
+@Data
+public class DuplicatedQuestionException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+  private final String message;
+
+  public DuplicatedQuestionException(ErrorCode errorCode, String message) {
+    super(message); // 부모 클래스에도 메시지 저장
+    this.errorCode = errorCode;
+    this.message = message;
+  }
+}

--- a/src/main/java/com/nlb/exception/ErrorCode.java
+++ b/src/main/java/com/nlb/exception/ErrorCode.java
@@ -27,7 +27,12 @@ public enum ErrorCode {
   METHOD_NOT_ALLOWED(405, "잘못된 Http Method"),
 
 
-  INTERNAL_SERVER_ERROR(500, "서버 내부 오류");
+  INTERNAL_SERVER_ERROR(500, "서버 내부 오류"),
+
+  //Exam 관련
+  DUPLICATED_QUESTIONID_EXIST(500, "중복 문제ID 존재"),
+  EXAM_NOT_FOUND(400, "시험이 존재하지 않습니다"),
+  EXAM_NOT_STARTED(400, "시험이 아직 시작되지 않았습니다");
 
   private final int code;
   private final String msg;

--- a/src/main/java/com/nlb/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nlb/exception/GlobalExceptionHandler.java
@@ -152,4 +152,21 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         return new ResponseEntity<>(CMResDTO.errorRes(errorCode), HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    // 권한 없음 (403)
+    @ExceptionHandler(CustomAccessDeniedException.class)
+    public ResponseEntity<CMResDTO<String>> handleAccessDeniedException(CustomAccessDeniedException e) {
+        log.error("[CustomAccessDeniedException] message: {}", e.getMessage());
+        return new ResponseEntity<>(
+            CMResDTO.errorWithMsgRes(ErrorCode.FORBIDDEN, e.getMessage()),
+            HttpStatus.FORBIDDEN
+        );    }
+
+    @ExceptionHandler(DuplicatedQuestionException.class)
+    public ResponseEntity<CMResDTO<String>> handleDuplicatedQuestionException(DuplicatedQuestionException e) {
+        log.error("[DuplicatedQuestionException] message: {}", e.getMessage());
+        return new ResponseEntity<>(CMResDTO.errorWithMsgRes(e.getErrorCode(), e.getMessage()), HttpStatus.CONFLICT);
+    }
+
+
 }

--- a/src/main/java/com/nlb/mapper/ExamMapper.java
+++ b/src/main/java/com/nlb/mapper/ExamMapper.java
@@ -2,34 +2,34 @@ package com.nlb.mapper;
 
 
 import com.nlb.vo.ExamVO;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Update;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Mapper
 @Repository
 public interface ExamMapper {
-    List<ExamVO> selectExamListByCreaterId(@Param("userId") int userId,
-                                           @Param("sortBy") String sortBy,
-                                           @Param("order") String order,
-                                           @Param("category") String category);
 
-    int updateExamActivationStatus(@Param("examId") int examId,
-                                   @Param("status") String status);
+  List<ExamVO> selectExamListByCreaterId(@Param("userId") int userId,
+      @Param("sortBy") String sortBy,
+      @Param("order") String order,
+      @Param("category") String category);
 
-    int deleteExamByExamId(@Param("examId") int examId);
+  int updateExamActivationStatus(@Param("examId") int examId,
+      @Param("status") String status);
 
-    int insertExam(ExamVO examVO);
+  int deleteExamByExamId(@Param("examId") int examId);
 
-    int updateExamById(ExamVO examVO);
+  int insertExam(ExamVO examVO);
 
-    int updateQuestionCount(@Param("examId") int examId, @Param("questionCount") int questionCount);
+  int updateExamById(ExamVO examVO);
 
-    List<ExamVO> selectExamList(@Param("sortBy") String sortBy,
-                                @Param("order") String order,
-                                @Param("category") String category);
+  int updateQuestionCount(@Param("examId") int examId, @Param("questionCount") int questionCount);
 
+  List<ExamVO> selectExamList(@Param("sortBy") String sortBy,
+      @Param("order") String order,
+      @Param("category") String category);
+
+  ExamVO selectExamById(@Param("examId") int examId);
 }

--- a/src/main/java/com/nlb/mapper/ExamResultMapper.java
+++ b/src/main/java/com/nlb/mapper/ExamResultMapper.java
@@ -3,28 +3,37 @@ package com.nlb.mapper;
 
 import com.nlb.dto.response.ExamResultCardDTO;
 import com.nlb.vo.ExamResultVO;
+import com.nlb.vo.ExamVO;
+import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Mapper
 @Repository
 public interface ExamResultMapper {
-    int deleteExamResultByExamId(@Param("examId") int examId);
-    List<ExamResultVO> selectExamResultList(@Param("examId") int examId,
-                                            @Param("sortBy") String sortBy,
-                                            @Param("order") String order,
-                                            @Param("isReviewed") Boolean isReviewed);
 
-    int updateExamResultIsReviewed(@Param("resultId") int resultId,
-                                   @Param("isReviewed") Boolean isReviewed);
+  int deleteExamResultByExamId(@Param("examId") int examId);
 
-    List<ExamResultVO> selectExamResultListByUserId(@Param("userId") int userId,
-                                                    @Param("sortBy") String sortBy,
-                                                    @Param("order") String order,
-                                                    @Param("isReviewed") Boolean isReviewed);
+  List<ExamResultVO> selectExamResultList(@Param("examId") int examId,
+      @Param("sortBy") String sortBy,
+      @Param("order") String order,
+      @Param("isReviewed") Boolean isReviewed);
 
-    ExamResultCardDTO selectExamResultAndExamByResultId(@Param("resultId") int resultId);
+  int updateExamResultIsReviewed(@Param("resultId") int resultId,
+      @Param("isReviewed") Boolean isReviewed);
+
+  List<ExamResultVO> selectExamResultListByUserId(@Param("userId") int userId,
+      @Param("sortBy") String sortBy,
+      @Param("order") String order,
+      @Param("isReviewed") Boolean isReviewed);
+
+  ExamResultCardDTO selectExamResultAndExamByResultId(@Param("resultId") int resultId);
+
+  int updateExamResult(ExamResultVO examResultVO);
+
+  void insertExamResult(ExamResultVO examResultVO);
+
+  ExamVO selectExamByCode(String examCode);
+
 }

--- a/src/main/java/com/nlb/service/ExamResultService.java
+++ b/src/main/java/com/nlb/service/ExamResultService.java
@@ -1,16 +1,33 @@
 package com.nlb.service;
 
 
+import com.nlb.dto.request.ExamResultReqDTO;
+import com.nlb.dto.response.ExamDataResDTO;
+import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
+import com.nlb.vo.AnswerVO;
 import com.nlb.vo.ExamResultVO;
-
 import java.util.List;
+import java.util.Map;
 
 public interface ExamResultService {
-    List<ExamResultVO> getExamResultList(int examId, String sortBy, String order, Boolean isReviewed);
-    int setExamResultStatus(int resultId, Boolean isReviewed);
 
-    List<ExamResultVO> getExamResultListOfUser(int userId, String sortBy, String order, Boolean isReviewed);
+  List<ExamResultVO> getExamResultList(int examId, String sortBy, String order, Boolean isReviewed);
 
-    ExamResultCardDTO getExamResultAndExam(int resultId);
+  int setExamResultStatus(int resultId, Boolean isReviewed);
+
+  List<ExamResultVO> getExamResultListOfUser(int userId, String sortBy, String order,
+      Boolean isReviewed);
+
+  ExamResultCardDTO getExamResultAndExam(int resultId);
+
+  int saveExamAnswers(int resultId, ExamResultReqDTO examResultReqDTO);
+
+  List<AnswerVO> submitExam(int resultId, ExamResultReqDTO examResultReqDTO);
+
+  ExamJoinResDTO joinExam(String examId, int examineeId, String entreeCode);
+
+  Map<String, Object> getExamResultData(int examId, int examineeId);
+
+  public ExamDataResDTO getExamData(int examId, int examineeId);
 }

--- a/src/main/java/com/nlb/service/ExamResultServiceImpl.java
+++ b/src/main/java/com/nlb/service/ExamResultServiceImpl.java
@@ -1,40 +1,251 @@
 package com.nlb.service;
 
 
+import com.mongodb.client.result.UpdateResult;
+import com.nlb.dto.request.ExamResultReqDTO;
+import com.nlb.dto.response.ExamDataResDTO;
+import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
+import com.nlb.exception.BadRequestException;
+import com.nlb.exception.CustomAccessDeniedException;
+import com.nlb.exception.ErrorCode;
+import com.nlb.exception.NotFoundException;
+import com.nlb.mapper.ExamMapper;
 import com.nlb.mapper.ExamResultMapper;
+import com.nlb.vo.AnswerVO;
+import com.nlb.vo.ExamResultMongoVO;
 import com.nlb.vo.ExamResultVO;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
+import com.nlb.vo.ExamVO;
+import com.nlb.vo.QuestionVO;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ExamResultServiceImpl implements ExamResultService {
 
-    @Autowired
-    private ExamResultMapper examResultMapper;
+  @Autowired
+  private ExamResultMapper examResultMapper;
+  @Autowired
+  private MongoTemplate mongoTemplate;
+  @Autowired
+  private ExamMapper examMapper;
+  @Autowired
+  private ExamService examService;
 
-    @Override
-    public List<ExamResultVO> getExamResultList(int examId, String sortBy, String order, Boolean isReviewed) {
-        return examResultMapper.selectExamResultList(examId, sortBy, order, isReviewed);
+
+  @Override
+  public List<ExamResultVO> getExamResultList(int examId, String sortBy, String order,
+      Boolean isReviewed) {
+    return examResultMapper.selectExamResultList(examId, sortBy, order, isReviewed);
+  }
+
+  @Override
+  public int setExamResultStatus(int resultId, Boolean isReviewed) {
+    return examResultMapper.updateExamResultIsReviewed(resultId, isReviewed);
+  }
+
+  @Override
+  public List<ExamResultVO> getExamResultListOfUser(int userId, String sortBy, String order,
+      Boolean isReviewed) {
+    return examResultMapper.selectExamResultListByUserId(userId, sortBy, order, isReviewed);
+  }
+
+  @Override
+  public ExamResultCardDTO getExamResultAndExam(int resultId) {
+    return examResultMapper.selectExamResultAndExamByResultId(resultId);
+  }
+
+
+  @Override
+  @Transactional
+  public int saveExamAnswers(int examineeId, ExamResultReqDTO examResultReqDTO) {
+
+    int resultId = examResultReqDTO.getExamResultVO().getResultId();
+    int dtoExamineeId = examResultReqDTO.getExamResultVO().getExamineeId();
+    // 세션 examineeId와 DTO examineeId가 일치하는지 확인
+    if (examineeId != dtoExamineeId) {
+      throw new CustomAccessDeniedException("잘못된 사용자 입니다");
+    }
+    if (examResultReqDTO.getExamResultVO().getSubmittedAt() != null) {
+      throw new CustomAccessDeniedException("이미 시험이 제출되었습니다");
     }
 
-    @Override
-    public int setExamResultStatus(int resultId, Boolean isReviewed) {
-        return examResultMapper.updateExamResultIsReviewed(resultId, isReviewed);
+    // 기존 몽고 데이터 가져와서 다른것 적용 (전체 덮어쓰기랑 비교해 IO 아껴보려는 시도...)
+    Query query = Query.query(
+        Criteria.where("resultId").is(resultId).and("examineeId").is(examineeId));
+    ExamResultMongoVO existingExamResult = mongoTemplate.findOne(query, ExamResultMongoVO.class,
+        "examResults");
+
+    List<AnswerVO> existingAnswers = existingExamResult.getAnswers();
+    List<AnswerVO> newAnswers = examResultReqDTO.getExamResultMongoVO().getAnswers();
+    // 기존 데이터 매핑
+    Map<Integer, AnswerVO> answerMap = existingAnswers.stream()
+        .collect(Collectors.toMap(AnswerVO::getQuestionId, a -> a));
+    // 답변 데이터 적용
+    for (AnswerVO newAnswer : newAnswers) {
+      answerMap.put(newAnswer.getQuestionId(), newAnswer);
     }
 
-    @Override
-    public List<ExamResultVO> getExamResultListOfUser(int userId, String sortBy, String order, Boolean isReviewed) {
-        return examResultMapper.selectExamResultListByUserId(userId, sortBy, order, isReviewed);
+    // 몽고 업데이트
+    Update update = new Update().set("answers", new ArrayList<>(answerMap.values()));
+    UpdateResult mongoResult = mongoTemplate.updateFirst(query, update, ExamResultMongoVO.class,
+        "examResults");
+
+    return (int) mongoResult.getMatchedCount();
+  }
+
+  @Override
+  @Transactional
+  public List<AnswerVO> submitExam(int examineeId, ExamResultReqDTO examResultReqDTO) {
+    int resultId = examResultReqDTO.getExamResultVO().getResultId();
+    int dtoExamineeId = examResultReqDTO.getExamResultVO().getExamineeId();
+    // 세션 examineeId와 DTO examineeId가 일치하는지 확인
+    if (examineeId != dtoExamineeId) {
+      throw new CustomAccessDeniedException("잘못된 사용자 입니다");
+    }
+    if (examResultReqDTO.getExamResultVO().getSubmittedAt() != null) {
+      throw new CustomAccessDeniedException("이미 시험이 제출되었습니다");
+    }
+    // MongoDB 업데이트
+    Query query = Query.query(
+        Criteria.where("resultId").is(resultId).and("examineeId").is(examineeId));
+    ExamResultMongoVO existingExamResult = mongoTemplate.findOne(query, ExamResultMongoVO.class,
+        "examResults");
+
+    List<AnswerVO> existingAnswers = existingExamResult.getAnswers();
+    List<AnswerVO> newAnswers = examResultReqDTO.getExamResultMongoVO().getAnswers();
+    // 기존 데이터 맵핑
+    Map<Integer, AnswerVO> answerMap = existingAnswers.stream()
+        .collect(Collectors.toMap(AnswerVO::getQuestionId, a -> a));
+    // 답변 데이터 적용
+    for (AnswerVO newAnswer : newAnswers) {
+      answerMap.put(newAnswer.getQuestionId(), newAnswer);
     }
 
-    @Override
-    public ExamResultCardDTO getExamResultAndExam(int resultId) {
-        return examResultMapper.selectExamResultAndExamByResultId(resultId);
+    // MongoDB 업데이트  (실제 제출에는 제출 시간 표기)
+    List<AnswerVO> updatedAnswers = new ArrayList<>(answerMap.values());
+    Update update = new Update()
+        .set("answers", updatedAnswers)
+        .set("submittedAt", LocalDateTime.now());
+
+    mongoTemplate.updateFirst(query, update, ExamResultMongoVO.class,
+        "examResults");
+
+    // RDB 업데이트 (시험 제출 상태)
+    ExamResultVO examResultVO = examResultReqDTO.getExamResultVO();
+    examResultVO.setResultId(resultId);
+    examResultVO.setSubmittedAt(LocalDateTime.now());
+    examResultVO.setReviewed(false);
+    examResultMapper.updateExamResult(examResultVO);
+
+    return updatedAnswers;
+  }
+
+  @Override
+  @Transactional
+  public ExamJoinResDTO joinExam(String examCode, int examineeId, String entreeCode) {
+    ExamVO examVO = examResultMapper.selectExamByCode(examCode);
+    System.out.println("examvo 조회 테스트 " + examVO);
+    int examId = examVO.getExamId(); // 조회한 examId 사용
+    System.out.println("examid 조회 세트스 " + examId);
+
+    if (examVO == null) {
+      // 시험이 존재하지 않음
+      throw new NotFoundException(ErrorCode.EXAM_NOT_FOUND);
+    }
+    if (!examVO.getActivationStatus().equals("on_going")) {
+      // 시험이 시작되지 않았거나 종료됨
+      throw new BadRequestException(ErrorCode.EXAM_NOT_STARTED);
+    }
+    if (!examVO.getEntreeCode().equals(entreeCode)) {
+      // 잘못된 비밀번호
+      throw new CustomAccessDeniedException("시험 입장 코드가 올바르지 않습니다.");
     }
 
+    // RDB에 새로운 resultId 생성 및 저장
+    ExamResultVO examResultVO = new ExamResultVO();
+    examResultVO.setExamId(examId);
+    examResultVO.setExamineeId(examineeId);
+    examResultVO.setScore(0);
+    examResultVO.setReviewed(false);
+    examResultMapper.insertExamResult(examResultVO);
+    int generatedResultId = examResultVO.getResultId();
+
+    // MongoDB에도 저장
+    Query query = Query.query(Criteria.where("resultId").is(generatedResultId));
+    Update update = new Update()
+        .set("resultId", generatedResultId)
+        .set("examId", examId)
+        .set("examineeId", examineeId)
+        .set("answers", new ArrayList<>()); // 초기 답변은 빈 리스트
+
+    mongoTemplate.upsert(query, update, ExamResultMongoVO.class, "examResults");
+    String DataUrl = URI.create(String.format("/api/exams/%d/exam-data", examId)).toString();
+
+    return new ExamJoinResDTO(
+        examId,
+        generatedResultId,
+        examCode,
+        examineeId,
+        DataUrl);
+  }
+
+
+  @Override
+  public Map<String, Object> getExamResultData(int examId, int examineeId) {
+    // MongoDB에서 해당 시험의 응시 데이터 가져오기
+    Query query = Query.query(Criteria.where("examId").is(examId)
+        .and("examineeId").is(examineeId));
+    ExamResultMongoVO examResultMongo = mongoTemplate.findOne(query, ExamResultMongoVO.class,
+        "examResults");
+    int resultId = examResultMongo.getResultId();
+
+    // 기존 응답 데이터 가져오기 (혹시 몰라 디폴트 빈 답변들 생성)
+    List<AnswerVO> answers =
+        examResultMongo.getAnswers() != null ? examResultMongo.getAnswers() : new ArrayList<>();
+
+    // JSON 응답 구조 구성
+    Map<String, Object> resultData = new HashMap<>();
+    resultData.put("examId", examId);
+    resultData.put("resultId", resultId); // (나중에 제출 시 필요)
+    resultData.put("examineeId", examineeId);
+    resultData.put("answers", answers);
+    return resultData;
+  }
+
+
+  @Override
+  public ExamDataResDTO getExamData(int examId, int examineeId) {
+    // 시험 문제 가져오기
+    List<QuestionVO> questions = examService.getExamQuestions(examId);
+
+    // 응시자가 제출한 데이터 가져오기
+    Map<String, Object> examResultData = getExamResultData(examId, examineeId);
+
+    int resultId = (int) examResultData.get("resultId");
+    List<AnswerVO> answers = (List<AnswerVO>) examResultData.getOrDefault("answers",
+        new ArrayList<>());
+
+    // 응답 DTO 구성
+    return new ExamDataResDTO(
+        examId,
+        resultId,
+        examineeId,
+        questions,
+        answers
+    );
+  }
 
 }

--- a/src/main/java/com/nlb/service/ExamService.java
+++ b/src/main/java/com/nlb/service/ExamService.java
@@ -1,22 +1,28 @@
 package com.nlb.service;
 
 
-import com.nlb.vo.ExamMongoVO;
+import com.nlb.dto.request.ExamReqDTO;
 import com.nlb.vo.ExamVO;
-
 import com.nlb.vo.QuestionVO;
 import java.util.List;
 
 public interface ExamService {
-    List<ExamVO> getExamList(int userId, String sortBy, String order, String category);
-    int setExamStatus(int examId, String status);
-    List<Integer> deleteExam(int examId);
 
-    int createExam(ExamMongoVO examMongoVO);
+  List<ExamVO> getExamList(int userId, String sortBy, String order, String category);
 
-    boolean updateExam(int examId, ExamMongoVO examMongoVO);
+  int setExamStatus(int examId, String status);
 
-    boolean updateQuestions(int examId, List<QuestionVO> questions);
+  List<Integer> deleteExam(int examId);
 
-    List<ExamVO> getAllExams(String sortBy, String order, String category);
+  int createExam(ExamReqDTO examReqDTO);
+
+  boolean updateExam(int examId, ExamReqDTO examReqDTO);
+
+  int updateQuestions(int examId, List<QuestionVO> questions);
+
+  List<ExamVO> getAllExams(String sortBy, String order, String category);
+
+  String getExamStatus(int examId);
+
+  List<QuestionVO> getExamQuestions(int examId);
 }

--- a/src/main/java/com/nlb/service/ExamServiceImpl.java
+++ b/src/main/java/com/nlb/service/ExamServiceImpl.java
@@ -2,26 +2,26 @@ package com.nlb.service;
 
 
 import com.mongodb.client.result.UpdateResult;
+import com.nlb.dto.request.ExamReqDTO;
+import com.nlb.exception.DuplicatedQuestionException;
+import com.nlb.exception.ErrorCode;
 import com.nlb.mapper.ExamMapper;
 import com.nlb.mapper.ExamResultMapper;
 import com.nlb.mapper.ResultDetailMapper;
-import com.nlb.repository.ExamRepository;
 import com.nlb.vo.ExamMongoVO;
 import com.nlb.vo.ExamVO;
 import com.nlb.vo.QuestionVO;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import javax.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Update;
-import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -59,89 +59,94 @@ public class ExamServiceImpl implements ExamService {
   }
 
   @Override
-  public int createExam(ExamMongoVO examMongoVO) {
-
+  public int createExam(ExamReqDTO examReqDTO) {
     //RDB 에 먼저 저장
-    ExamVO examVO = converToExamVO(examMongoVO);
+    ExamVO examVO = examReqDTO.getExamVO();
+    examVO.setCreaterId(1); //todo 로그인 생기면 세션에서 가져오는 로직으로 변경
+
+    //RDB에 저장하고 생성된 ID 값과 같은 examId 값으로 몽고db에 저장 (몽고의 _id랑 별개)
     examMapper.insertExam(examVO);
-
-    //RDB에 저장하고 생성된 ID 값과 같은 examId 값으로 몽고db에 저장 (_id랑 별개 ㅠㅠ)
     int generatedId = examVO.getExamId();
-    System.out.println("getExamId 테스트 입니다 +" + generatedId);
-    examMongoVO.setExamId(generatedId);
 
-    //examRepository.save(examMongoVO); //둘중 원하는 방식으로 사용
-    mongoTemplate.save(examMongoVO, "exams");  //todo 컬렉션네이밍 픽스해야함(템플릿은)
+    //몽고에 저장
+    Query query = Query.query(Criteria.where("examId").is(generatedId));
+    Update update = new Update()
+        .set("examId", generatedId)
+        .set("title", examVO.getTitle())
+        .set("category", examVO.getCategory())
+        .set("entreeCode", examVO.getEntreeCode())
+        .set("examTime", examVO.getExamTime())
+        .set("startedAt", examVO.getStartedAt())
+        .set("finishedAt", examVO.getFinishedAt());
+//        .set("questionCount",
+//            examMongoVO.getQuestions() != null ? examMongoVO.getQuestions().size() : 0)
+//        .set("questions", examMongoVO.getQuestions());
+    mongoTemplate.upsert(query, update, ExamMongoVO.class, "exams");
 
     return generatedId;
   }
 
   @Override
   @Transactional
-  public boolean updateExam(int examId, ExamMongoVO updatedExamVO) {
+  public boolean updateExam(int examId, ExamReqDTO examReqDTO) {
+    // RDB 업데이트 (ExamVO)
+    ExamVO examVO = examReqDTO.getExamVO();
+    examVO.setExamId(examId);  // examId 설정
+    int rowsUpdated = examMapper.updateExamById(examVO);  // RDB에 기본 정보 업데이트
 
-    Query query = new Query(Criteria.where("examId").is(examId));
-    Update update = new Update();
+    // MongoDB 업데이트 (ExamMongoVO)
+    ExamMongoVO examMongoVO = examReqDTO.getExamMongoVO();
+    Query query = Query.query(Criteria.where("examId").is(examId));  // examId로 MongoDB에서 찾기
+    Update update = new Update()
+        .set("title", examVO.getTitle())
+        .set("category", examVO.getCategory())
+        .set("entreeCode", examVO.getEntreeCode())
+        .set("examTime", examVO.getExamTime())
+        .set("startedAt", examVO.getStartedAt())
+        .set("finishedAt", examVO.getFinishedAt())
+        .set("questionCount",
+            examMongoVO.getQuestions() != null ? examMongoVO.getQuestions().size() : 0)  // 문제 개수
+        .set("questions", examMongoVO.getQuestions());
+    UpdateResult mongoResult = mongoTemplate.updateFirst(query, update, ExamMongoVO.class,
+        "exams");  // MongoDB 업데이트
 
-    update.set("title", updatedExamVO.getTitle());
-    update.set("category", updatedExamVO.getCategory());
-    update.set("entreeCode", updatedExamVO.getEntreeCode());
-    update.set("examTime", updatedExamVO.getExamTime());
-    update.set("startedAt", updatedExamVO.getStartedAt());
-    update.set("finishedAt", updatedExamVO.getFinishedAt());
+    // RDB의 question_count 업데이트
+    if (examMongoVO.getQuestions() != null) {
+      int questionCount = examMongoVO.getQuestions().size();  // MongoDB의 questions 리스트 크기
+      examMapper.updateQuestionCount(examId, questionCount);  // RDB의 question_count 업데이트
+    }
 
-    // MongoDB 업데이트 수행
-    UpdateResult result = mongoTemplate.updateFirst(query, update, ExamMongoVO.class, "exams");
-
-    //RDB 업데이트: 전체 VO 변환 후 업데이트 수행
-    ExamMongoVO examMongVO = findExamByExamId(examId);
-
-    ExamVO examVO = converToExamVO(examMongVO);
-    int rowsUpdated = examMapper.updateExamById(examVO);
-
-    return result.getMatchedCount() > 0 && rowsUpdated > 0;
+    return rowsUpdated > 0 && mongoResult.getMatchedCount() > 0;
 
   }
 
   @Override
   @Transactional
-  public boolean updateQuestions(int examId, List<QuestionVO> Questions) {
+  public int updateQuestions(int examId, List<QuestionVO> Questions) {
+
+    Set<Integer> dupcheck = new HashSet<>();
+    for (QuestionVO q : Questions) {
+      if (!dupcheck.add(q.getQuestionId())) { // 중복 발견
+        throw new DuplicatedQuestionException(ErrorCode.DUPLICATED_QUESTIONID_EXIST,
+            "중복된 questionId가 포함되어 있습니다.");
+      }
+    }
+
     Query query = new Query();
     query.addCriteria(Criteria.where("examId").is(examId)); // 조건: examId로 검색
 
-    Update update = new Update();
-    update.set("questions", Questions); // 질문 리스트 통째로 업데이트
-    // 프론트에서 전달받은 질문 리스트로 업데이트
+    Update update = new Update()
+        .set("questionCount", Questions.size())
+        .set("questions", Questions);
 
-    // MongoDB에 업데이트
     UpdateResult result = mongoTemplate.updateFirst(query, update, ExamMongoVO.class, "exams");
+    //까지 몽고DB 업데이트
 
-    if (result.getMatchedCount() > 0) {
-      // RDB에 question_count 필드에도 업데이트
-      int questionCount = Questions.size();
-      examMapper.updateQuestionCount(examId, questionCount);
-      return true;
-    }
-    return false;
-  }
+    // RDB에 question_count 필드에도 업데이트
+    int questionCount = Questions.size();
+    examMapper.updateQuestionCount(examId, questionCount);
 
-
-  //RDB 동시 저장목적 nosql용VO -> RDB용VO 변환 메서드
-  private ExamVO converToExamVO(ExamMongoVO examMongoVO) {
-    ExamVO examVO = new ExamVO();
-    examVO.setExamId(examMongoVO.getExamId());
-    //examVO.setCreatorId((int)session.getAttribute("userId")); //todo 로그인 컨트롤러에서 저장로직 필요! or 토큰쓴다면 토큰에서 꺼내는 로직 논의 필요
-    examVO.setCreaterId(1);
-    examVO.setExamCode(examMongoVO.getExamCode());
-    examVO.setTitle(examMongoVO.getTitle());
-    examVO.setCategory(examMongoVO.getCategory());
-    examVO.setEntreeCode(examMongoVO.getEntreeCode());
-    examVO.setQuestionCount(examMongoVO.getQuestionCount());
-    examVO.setExamTime(examMongoVO.getExamTime());
-    examVO.setStartedAt(examMongoVO.getStartedAt());
-    examVO.setFinishedAt(examMongoVO.getFinishedAt());
-    examVO.setActivationStatus("not-started"); // 기본값
-    return examVO;
+    return (int) result.getMatchedCount();
   }
 
   //고유 _id 가 없어서 examId를 찾을때 query 객체로 찾아야하는 용도 메서드
@@ -151,8 +156,24 @@ public class ExamServiceImpl implements ExamService {
     return mongoTemplate.findOne(query, ExamMongoVO.class, "exams");
   }
 
-    @Override
-    public List<ExamVO> getAllExams(String sortBy, String order, String category) {
-        return examMapper.selectExamList(sortBy, order, category);
-    }
+
+  @Override
+  public List<QuestionVO> getExamQuestions(int examId) {
+    ExamMongoVO examMongoVO = mongoTemplate.findOne(
+        Query.query(Criteria.where("examId").is(examId)),
+        ExamMongoVO.class, "exams");
+    return examMongoVO != null ? examMongoVO.getQuestions() : new ArrayList<>();
+  }
+
+  @Override
+  public String getExamStatus(int examId) {
+    ExamVO examVO = examMapper.selectExamById(examId);
+    return examVO != null ? examVO.getActivationStatus() : "null";
+  }
+
+
+  @Override
+  public List<ExamVO> getAllExams(String sortBy, String order, String category) {
+    return examMapper.selectExamList(sortBy, order, category);
+  }
 }

--- a/src/main/java/com/nlb/vo/AnswerVO.java
+++ b/src/main/java/com/nlb/vo/AnswerVO.java
@@ -1,0 +1,25 @@
+package com.nlb.vo;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// 응시자의 답변 주의 : 답안지가 아님!!!!!!!
+@Getter
+@Setter
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnswerVO {
+
+  private int questionId;
+  private String answer;           // 응시자가 선택한 답변
+  private boolean isCorrect;       // 정답 여부
+  private int pointsEarned;        // 획득 점수
+  private boolean isObjection;     // 이의제기 여부
+  private String objectionComments; // 이의제기 코멘트 (이의제기 시)
+  private String objectionReply;   // 이의제기에 대한 답변
+}

--- a/src/main/java/com/nlb/vo/ExamMongoVO.java
+++ b/src/main/java/com/nlb/vo/ExamMongoVO.java
@@ -1,11 +1,12 @@
 package com.nlb.vo;
 
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import java.time.LocalDateTime;
-import lombok.*;
-
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -14,19 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 public class ExamMongoVO {      // MongoDB 에 시험 디테일 저장하는 VO
 
-    private int examId;  //todo 유니크ID 관련, examVO랑 매칭 컨벤션 정리 필요
-    private String examCode;
-    private String title;
-    private String category;
-    private String entreeCode;
-    private int questionCount;
-    private int examTime;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    private LocalDateTime startedAt;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    private LocalDateTime finishedAt;
-
-
-    private List<QuestionVO> questions;
+  private int examId;
+  private List<QuestionVO> questions;
 }
 

--- a/src/main/java/com/nlb/vo/ExamResultMongoVO.java
+++ b/src/main/java/com/nlb/vo/ExamResultMongoVO.java
@@ -1,10 +1,12 @@
 package com.nlb.vo;
 
 
-import lombok.*;
-
 import java.util.List;
-import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -12,25 +14,7 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ExamResultMongoVO {
-    private int resultId;
-    private int examId;
-    private int examineeId;
-    private List<Answer> answers;
-    private String submittedAt;
 
-    // 응시자의 답변 주의 : 답안지가 아님!!!!!!!
-    @Getter
-    @Setter
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class Answer {
-        private int questionId;
-        private String answer;           // 응시자가 선택한 답변
-        private boolean isCorrect;       // 정답 여부
-        private int pointsEarned;        // 획득 점수
-        private boolean isObjection;     // 이의제기 여부
-        private String objectionComments; // 이의제기 코멘트 (이의제기 시)
-        private String objectionReply;   // 이의제기에 대한 답변
-    }
+  private int resultId;
+  private List<AnswerVO> answers;
 }

--- a/src/main/java/com/nlb/vo/ExamResultVO.java
+++ b/src/main/java/com/nlb/vo/ExamResultVO.java
@@ -1,9 +1,13 @@
 package com.nlb.vo;
 
-import lombok.*;
-
-import java.util.Date;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -11,13 +15,15 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ExamResultVO {
-    private int resultId;
-    private int examId;
-    private int examineeId;
-    private int score; // Range: 0-100
-    private String submittedAt; // Default: sysdate
-    private boolean isReviewed; // Default: false
+
+  private int resultId;
+  private int examId;
+  private int examineeId;
+  private int score; // Range: 0-100
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime submittedAt; // Default: sysdate
+  private boolean isReviewed; // Default: false
 
 
-    private List<ResultDetailVO> resultDetails;
+  private List<ResultDetailVO> resultDetails;
 }

--- a/src/main/java/com/nlb/vo/ExamVO.java
+++ b/src/main/java/com/nlb/vo/ExamVO.java
@@ -2,28 +2,26 @@ package com.nlb.vo;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
-import lombok.*;
+import lombok.Data;
 
-@Getter
-@Setter
+
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
 public class ExamVO {
-    private int examId;
-    private int createrId;      //todo er? or?
-    private String examCode;
-    private String title;
-    private String category;
-    private String entreeCode;
-    private int questionCount;
-    private int examineeCount; // Default: 0
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    private String createdAt; // Default: sysdate
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    private LocalDateTime startedAt;
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSSSS")
-    private LocalDateTime finishedAt;
-    private int examTime;  //  분단위
-    private String activationStatus; // 'not_started', 'on_going', 'closed'
+
+  private int examId;
+  private int createrId;      //todo er? or?
+  private String examCode;
+  private String title;
+  private String category;
+  private String entreeCode;
+  private int questionCount;
+  private int examineeCount; // Default: 0
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime createdAt; // Default: sysdate
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime startedAt;
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime finishedAt;
+  private int examTime;  //  분단위
+  private String activationStatus; // 'not_started', 'on_going', 'closed'
 }

--- a/src/main/java/com/nlb/vo/NlbUserVO.java
+++ b/src/main/java/com/nlb/vo/NlbUserVO.java
@@ -1,8 +1,10 @@
 package com.nlb.vo;
 
-import lombok.*;
-
-import java.util.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -10,12 +12,13 @@ import java.util.Date;
 @AllArgsConstructor
 @NoArgsConstructor
 public class NlbUserVO {
-    private int userId;
-    private String loginId;
-    private String password;
-    private String nickname;
-    private String email;
-    private String userRole; // 'user', 'admin'
-    private String regDate; // Default: sysdate
-    private boolean isActive; // Default: true
+
+  private int userId;
+  private String loginId;
+  private String password;
+  private String nickname;
+  private String email;
+  private String userRole; // 'user', 'admin'
+  private String regDate; // Default: sysdate
+  private boolean isActive; // Default: true
 }

--- a/src/main/resources/mapper/exam-mapper.xml
+++ b/src/main/resources/mapper/exam-mapper.xml
@@ -1,104 +1,113 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.nlb.mapper.ExamMapper">
 
-    <!-- 회원이 만든 시험 리스트 조회 -->
-    <select id="selectExamListByCreaterId"  resultType="ExamVO">
-        SELECT *
-        FROM exam
-        WHERE creater_id = #{userId}
-        <if test="category != null and category != ''">
-            AND category = #{category}
-        </if>
-        <choose>
-            <when test="sortBy == 'title'">
-                ORDER BY title ${order}
-            </when>
-            <when test="sortBy == 'createdAt'">
-                ORDER BY created_at ${order}
-            </when>
-            <when test="sortBy == 'examineeCount'">
-                ORDER BY examinee_count ${order}
-            </when>
-            <when test="sortBy == 'category'">
-                ORDER BY category ${order}
-            </when>
-            <otherwise>
-                ORDER BY created_at ASC
-            </otherwise>
-        </choose>
-    </select>
+  <!-- 회원이 만든 시험 리스트 조회 -->
+  <select id="selectExamListByCreaterId" resultType="ExamVO">
+    SELECT *
+    FROM exam
+    WHERE creater_id = #{userId}
+    <if test="category != null and category != ''">
+      AND category = #{category}
+    </if>
+    <choose>
+      <when test="sortBy == 'title'">
+        ORDER BY title ${order}
+      </when>
+      <when test="sortBy == 'createdAt'">
+        ORDER BY created_at ${order}
+      </when>
+      <when test="sortBy == 'examineeCount'">
+        ORDER BY examinee_count ${order}
+      </when>
+      <when test="sortBy == 'category'">
+        ORDER BY category ${order}
+      </when>
+      <otherwise>
+        ORDER BY created_at ASC
+      </otherwise>
+    </choose>
+  </select>
 
-    <update id = "updateExamActivationStatus">
-        update exam
-        set activation_status = #{status}
-        where exam_id = #{examId}
-    </update>
+  <update id="updateExamActivationStatus">
+    update exam
+    set activation_status = #{status}
+    where exam_id = #{examId}
+  </update>
 
-    <delete id = "deleteExamByExamId">
-        delete from exam
-        where exam_id = #{examId}
-    </delete>
+  <delete id="deleteExamByExamId">
+    delete
+    from exam
+    where exam_id = #{examId}
+  </delete>
 
-    <!-- RDB에서 생성된 자동 id 필드를 가져오기 위한 설정들 추가 -->
-    <insert id="insertExam" parameterType="ExamVO" useGeneratedKeys="true" keyProperty="examId">
-        INSERT INTO exam (
-            creater_id, exam_code, title, category, entree_code,
-            question_count, examinee_count, created_at, started_at, finished_at,
-            exam_time, activation_status
-        ) VALUES (
-                     #{createrId}, #{examCode}, #{title}, #{category}, #{entreeCode},
-                     #{questionCount}, 0, NOW(), #{startedAt}, #{finishedAt},
-                     #{examTime}, #{activationStatus}
-                 )
-    </insert>
+  <!-- RDB에서 생성된 자동 id 필드를 가져오기 위한 설정들 추가 -->
+  <insert id="insertExam" parameterType="ExamVO" useGeneratedKeys="true" keyProperty="examId">
+    INSERT INTO exam (creater_id, exam_code, title, category, entree_code,
+                      question_count, examinee_count, created_at, started_at, finished_at,
+                      exam_time, activation_status)
+    VALUES (#{createrId}, #{examCode}, #{title}, #{category}, #{entreeCode},
+            0, 0, NOW(), #{startedAt}, #{finishedAt},
+            #{examTime}, COALESCE(#{activationStatus}, 'not_started'))
+  </insert>
 
-    <update id="updateExamById" parameterType="ExamVO">
-        UPDATE exam
-        SET
-            title = #{title},
-            category = #{category},
-            entree_code = #{entreeCode},
-            exam_time = #{examTime},
-            started_at = #{startedAt},
-            finished_at = #{finishedAt}
-        WHERE exam_id = #{examId}
-    </update>
+  <update id="updateExamById" parameterType="ExamVO">
+    UPDATE exam
+    SET title       = #{title},
+        category    = #{category},
+        entree_code = #{entreeCode},
+        exam_time   = #{examTime},
+        started_at  = #{startedAt},
+        finished_at = #{finishedAt}
+    WHERE exam_id = #{examId}
+  </update>
 
-    <update id="updateQuestionCount" parameterType="map">
-        UPDATE exam
-        SET question_count = #{questionCount}
-        WHERE exam_id = #{examId}
-    </update>
+  <update id="updateQuestionCount" parameterType="map">
+    UPDATE exam
+    SET question_count = #{questionCount}
+    WHERE exam_id = #{examId}
+  </update>
 
 
-    <!-- 모든 시험 리스트 조회 -->
-    <select id="selectExamList"  resultType="ExamVO">
-        SELECT *
-        FROM exam
-        <if test="category != null and category != ''">
-            AND category = #{category}
-        </if>
-        <choose>
-            <when test="sortBy == 'title'">
-                ORDER BY title ${order}
-            </when>
-            <when test="sortBy == 'createdAt'">
-                ORDER BY created_at ${order}
-            </when>
-            <when test="sortBy == 'examineeCount'">
-                ORDER BY examinee_count ${order}
-            </when>
-            <when test="sortBy == 'category'">
-                ORDER BY category ${order}
-            </when>
-            <otherwise>
-                ORDER BY created_at ASC
-            </otherwise>
-        </choose>
-    </select>
+  <!-- 모든 시험 리스트 조회 -->
+  <select id="selectExamList" resultType="ExamVO">
+    SELECT *
+    FROM exam
+    <if test="category != null and category != ''">
+      AND category = #{category}
+    </if>
+    <choose>
+      <when test="sortBy == 'title'">
+        ORDER BY title ${order}
+      </when>
+      <when test="sortBy == 'createdAt'">
+        ORDER BY created_at ${order}
+      </when>
+      <when test="sortBy == 'examineeCount'">
+        ORDER BY examinee_count ${order}
+      </when>
+      <when test="sortBy == 'category'">
+        ORDER BY category ${order}
+      </when>
+      <otherwise>
+        ORDER BY created_at ASC
+      </otherwise>
+    </choose>
+  </select>
 
+  <select id="selectExamResultByExamIdAndExamineeId" resultType="ExamResultVO">
+    SELECT *
+    FROM exam_result
+    WHERE exam_id = #{examId}
+      AND examinee_id = #{examineeId}
+  </select>
+
+  <select id="selectExamById" parameterType="int" resultType="ExamVO">
+    SELECT *
+    FROM exam
+    WHERE exam_id = #{examId}
+  </select>
 
 </mapper>

--- a/src/main/resources/mapper/exam-result-mapper.xml
+++ b/src/main/resources/mapper/exam-result-mapper.xml
@@ -1,75 +1,100 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 
 <mapper namespace="com.nlb.mapper.ExamResultMapper">
 
-    <delete id="deleteExamResultByExamId">
-        delete from exam_result
-        where exam_id = #{examId}
-    </delete>
+  <delete id="deleteExamResultByExamId">
+    delete
+    from exam_result
+    where exam_id = #{examId}
+  </delete>
 
 
-    <!-- 시험 응시자 결과 조회 -->
-    <select id="selectExamResultList" resultType="ExamResultVO">
-        SELECT *
-        FROM exam_result
-        WHERE exam_id = #{examId}
-        <if test="isReviewed != null">
-            AND is_reviewed = #{isReviewed}
-        </if>
-        <choose>
-            <when test="sortBy == 'submittedAt'">
-                ORDER BY submitted_at ${order}
-            </when>
-            <when test="sortBy == 'score'">
-                ORDER BY score ${order}
-            </when>
-            <otherwise>
-                ORDER BY submitted_at ASC
-            </otherwise>
-        </choose>
-    </select>
+  <!-- 시험 응시자 결과 조회 -->
+  <select id="selectExamResultList" resultType="ExamResultVO">
+    SELECT *
+    FROM exam_result
+    WHERE exam_id = #{examId}
+    <if test="isReviewed != null">
+      AND is_reviewed = #{isReviewed}
+    </if>
+    <choose>
+      <when test="sortBy == 'submittedAt'">
+        ORDER BY submitted_at ${order}
+      </when>
+      <when test="sortBy == 'score'">
+        ORDER BY score ${order}
+      </when>
+      <otherwise>
+        ORDER BY submitted_at ASC
+      </otherwise>
+    </choose>
+  </select>
 
-    <update id="updateExamResultIsReviewed">
-        update exam_result
-        set is_reviewed = #{isReviewed}
-        where result_id = #{resultId}
-    </update>
+  <update id="updateExamResultIsReviewed">
+    update exam_result
+    set is_reviewed = #{isReviewed}
+    where result_id = #{resultId}
+  </update>
 
 
-    <!-- 회원이 응시한 시험 결과 리스트 조회 -->
-    <select id="selectExamResultListByUserId"  resultType="ExamResultVO">
-        SELECT *
-        FROM exam_result
-        WHERE examinee_id = #{userId}
-        <if test="isReviewed != null">
-            AND is_reviewed = #{isReviewed}
-        </if>
-        <choose>
-            <when test="sortBy == 'submittedAt'">
-                ORDER BY submitted_at ${order}
-            </when>
-            <when test="sortBy == 'score'">
-                ORDER BY score ${order}
-            </when>
-            <otherwise>
-                ORDER BY submitted_at ASC
-            </otherwise>
-        </choose>
-    </select>
+  <!-- 회원이 응시한 시험 결과 리스트 조회 -->
+  <select id="selectExamResultListByUserId" resultType="ExamResultVO">
+    SELECT *
+    FROM exam_result
+    WHERE examinee_id = #{userId}
+    <if test="isReviewed != null">
+      AND is_reviewed = #{isReviewed}
+    </if>
+    <choose>
+      <when test="sortBy == 'submittedAt'">
+        ORDER BY submitted_at ${order}
+      </when>
+      <when test="sortBy == 'score'">
+        ORDER BY score ${order}
+      </when>
+      <otherwise>
+        ORDER BY submitted_at ASC
+      </otherwise>
+    </choose>
+  </select>
 
-    <select id = "selectExamResultAndExamByResultId" resultType="ExamResultCardDTO">
-        SELECT
-            e.*, -- ExamVO의 모든 필드
-            er.result_id, er.examinee_id, er.score, er.submitted_at, er.is_reviewed -- ExamResultVO의 모든 필드
-        FROM
-            exam e
-                JOIN
-            exam_result er ON e.exam_id = er.exam_id
-        WHERE
-            er.result_id = #{resultId}
-    </select>
+  <select id="selectExamResultAndExamByResultId" resultType="ExamResultCardDTO">
+    SELECT e.*,           -- ExamVO의 모든 필드
+           er.result_id,
+           er.examinee_id,
+           er.score,
+           er.submitted_at,
+           er.is_reviewed -- ExamResultVO의 모든 필드
+    FROM exam e
+           JOIN
+         exam_result er ON e.exam_id = er.exam_id
+    WHERE er.result_id = #{resultId}
+  </select>
+
+  <!-- 시험 제출시 세팅 값들 업데이트 -->
+  <update id="updateExamResult">
+    update exam_result
+    set submitted_at = #{submittedAt},
+        is_reviewed  = #{isReviewed}
+    where result_id = #{resultId}
+  </update>
+
+
+  <!-- 첫 입장시 result 관련 초기 데이터 입력-->
+  <insert id="insertExamResult" parameterType="ExamResultVO" useGeneratedKeys="true"
+    keyProperty="resultId">
+    INSERT INTO exam_result (exam_id, examinee_id, score, submitted_at, is_reviewed)
+    VALUES (#{examId}, #{examineeId}, 0, NOW(), false)
+  </insert>
+
+  <select id="selectExamByCode" parameterType="String" resultType="ExamVO">
+    SELECT *
+    FROM exam
+    WHERE exam_code = #{examCode}
+  </select>
+
 </mapper>


### PR DESCRIPTION
closed #39 

📣 **To Reviewers**
📌 시험지 생성 
- 시험 초기 데이터 등록/수정 기능
-> RDB / 몽고DB 에 필요한 필드들 동시에 저장합니다
- 객/주관식 질문 등록/수정 기능
-> 몽고 DB에 필요한 필드들 동시에 저장하고  RDB의 문제 개수 필드 업데이트 합니다.

📌 시험 응시
- 시험 응시 전 입장단계의 API (Join) 으로 RDB/몽고 DB에 초기 resultId 를 등록합니다
 (이후 문제지 가져오거나 응답 가져올때 참조하기 위함)
 👉 Join 이후 
- 시험지 데이터 조회 
- 응시자 시험 응답 제출
- 응시자 시험지 최종 제출 (submittedAT 을 이때 등록 -> 이 값의 유무로 시험 제출 완료 검증)

