### PR TITLE
Feat/#88 시험응시 프론트 백엔드 연결 1차

### DIFF
--- a/src/main/java/com/nlb/controller/ExamController.java
+++ b/src/main/java/com/nlb/controller/ExamController.java
@@ -1,7 +1,5 @@
 package com.nlb.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,14 +10,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequestMapping("/api/exams")
 public class ExamController {
 
-    @GetMapping("/create-exam")
-    public String showCreateExamPage(@RequestParam("examId") int examId, Model model) {
-        model.addAttribute("examId", examId);
-        return "jsp/exam/create_exam";
-    }
+  @GetMapping("/create-exam")
+  public String showCreateExamPage(@RequestParam("examId") int examId, Model model) {
+    model.addAttribute("examId", examId);
+    return "jsp/exam/create_exam";
 
-@RestController
-@RequestMapping("/api/exams")
-public class ExamController {
+  }
 
 }

--- a/src/main/java/com/nlb/controller/ExamResultController.java
+++ b/src/main/java/com/nlb/controller/ExamResultController.java
@@ -1,8 +1,61 @@
 package com.nlb.controller;
 
 
+import com.nlb.dto.response.ExamJoinResDTO;
+import com.nlb.service.ExamResultService;
+import javax.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
 
 @Controller
+@RequestMapping("/api/exams/results")
 public class ExamResultController {
+
+  @Autowired
+  ExamResultService examResultService;
+
+
+  // 시험에 응시 후, 응시 페이지로 리다이렉트
+  @GetMapping("/join/{examId}")
+  public String joinExam(
+      @PathVariable("examId") int examId,
+      @RequestParam("examCode") String examCode,
+      @RequestParam("entreeCode") String entreeCode,
+      HttpSession session,
+      Model model) {
+
+    // 세션에서 가져오도록 변경 (현재는 1로 하드코딩)
+    int examineeId =
+        (session.getAttribute("userId") != null) ? (int) session.getAttribute("userId") : 1;
+
+    ExamJoinResDTO joinResponse = examResultService.joinExam(examId, examCode, examineeId,
+        entreeCode);
+    // 세션에 데이터 저장 (이후 API 요청에서 사용)
+    session.setAttribute("examId", joinResponse.getExamId());
+    session.setAttribute("examineeId", joinResponse.getExamineeId());
+
+    System.out.println("joinExam() - 저장된 examId: " + joinResponse.getExamId());
+    System.out.println("joinExam() - 저장된 examineeId: " + joinResponse.getExamineeId());
+
+    return "redirect:/api/exams/results/exam/take";
+  }
+
+  @GetMapping("/exam/take")
+  public String takeExam(HttpSession session, Model model) {
+    Integer examId = (Integer) session.getAttribute("examId");
+    //todo 들어온 세션과 지금 세션의 동일 체크 필요?
+    System.out.println("examID 테스트  = " + examId);
+    if (examId == null) {
+      return "redirect:/exam-list"; // 시험 목록으로 리디렉트
+    }
+
+    model.addAttribute("examId", examId);
+    return "jsp/exam/take_exam";
+  }
 }

--- a/src/main/java/com/nlb/controller/ExamResultRestController.java
+++ b/src/main/java/com/nlb/controller/ExamResultRestController.java
@@ -3,10 +3,9 @@ package com.nlb.controller;
 
 import com.nlb.dto.request.ExamResultReqDTO;
 import com.nlb.dto.response.CMResDTO;
-import com.nlb.dto.response.ExamDataResDTO;
-import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
 import com.nlb.dto.response.ExamineeInfoResDTO;
+import com.nlb.dto.response.FullExamDataResDTO;
 import com.nlb.exception.ErrorCode;
 import com.nlb.service.ExamResultService;
 import com.nlb.vo.AnswerVO;
@@ -119,20 +118,6 @@ public class ExamResultRestController {
         HttpStatus.OK);
   }
 
-  //시험 입장
-  @PostMapping("/{examId}/join")
-  public ResponseEntity<CMResDTO<ExamJoinResDTO>> joinExam(
-      @PathVariable int examId,
-      @RequestParam String examCode,
-      @RequestParam String entreeCode) {
-    //Integer examineeId = (Integer) session.getAttribute("userId");
-    //todo 로그인 개발되면 세션으로 변경
-    int examineeId = 1;
-    ExamJoinResDTO response = examResultService.joinExam(examId, examCode, examineeId,
-        entreeCode);
-
-    return new ResponseEntity<>(CMResDTO.successDataRes(response), HttpStatus.OK);
-  }
 
   // 제출 답안 상세 조회
   @GetMapping("/{examId}/answers")
@@ -154,17 +139,19 @@ public class ExamResultRestController {
 
   //시험 입장 후 데이터 조회 ( 문제 + 내가 입력한 답안 )
   @GetMapping("/{examId}/exam-data")
-  public ResponseEntity<CMResDTO<ExamDataResDTO>> getExamDataForUser(
+  public ResponseEntity<CMResDTO<FullExamDataResDTO>> getExamDataForUser(
       @PathVariable("examId") int examId,
       HttpSession session) {
-    //todo 로그인 개발되면 사용
-    //Integer examineeId = (Integer) session.getAttribute("userId");
+    // 로그인 기능 개발 시 사용
+    // Integer examineeId = (Integer) session.getAttribute("userId");
 
     int examineeId = 1;
 
-    ExamDataResDTO examData = examResultService.getExamData(examId, examineeId);
+    FullExamDataResDTO examData = examResultService.getExamData(examId, examineeId);
+    System.out.println(examData);
     return new ResponseEntity<>(CMResDTO.successDataRes(examData), HttpStatus.OK);
   }
+
 
   //
   @GetMapping("/{examId}/{resultId}/details")

--- a/src/main/java/com/nlb/dto/response/FullExamDataResDTO.java
+++ b/src/main/java/com/nlb/dto/response/FullExamDataResDTO.java
@@ -1,0 +1,31 @@
+package com.nlb.dto.response;
+
+import com.nlb.vo.AnswerVO;
+import com.nlb.vo.QuestionVO;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FullExamDataResDTO {
+
+  private int examId;
+  private String title;
+  private String category;
+  private int createrId;
+  private String entreeCode;
+  private int examTime;
+  private LocalDateTime startedAt;
+  private LocalDateTime finishedAt;
+  private int questionCount;
+  private int resultId;
+  private int examineeId;
+  private List<QuestionVO> questions;
+  private List<AnswerVO> submittedAnswers;
+
+}

--- a/src/main/java/com/nlb/service/ExamResultService.java
+++ b/src/main/java/com/nlb/service/ExamResultService.java
@@ -2,10 +2,10 @@ package com.nlb.service;
 
 
 import com.nlb.dto.request.ExamResultReqDTO;
-import com.nlb.dto.response.ExamDataResDTO;
 import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
 import com.nlb.dto.response.ExamineeInfoResDTO;
+import com.nlb.dto.response.FullExamDataResDTO;
 import com.nlb.vo.AnswerVO;
 import com.nlb.vo.ExamResultVO;
 import java.util.List;
@@ -18,7 +18,7 @@ public interface ExamResultService {
   int setExamResultStatus(int resultId, Boolean isReviewed);
 
   List<ExamResultVO> getExamResultListOfUser(int userId, String sortBy, String order,
-                                             Boolean isReviewed);
+      Boolean isReviewed);
 
   ExamResultCardDTO getExamResultAndExam(int resultId);
 
@@ -32,23 +32,26 @@ public interface ExamResultService {
 
   Map<String, Object> getExamResultData(int examId, int examineeId);
 
-  public ExamDataResDTO getExamData(int examId, int examineeId);
+  public FullExamDataResDTO getExamData(int examId, int examineeId);
 
   public List<AnswerVO> gradingExam(List<AnswerVO> answers, ExamResultVO examResultVO, int resultId,
-                                    int examId);
+      int examId);
 
   public ExamResultVO getResultDetail(int examineeId, int examId, int resultId);
 
   public ExamineeInfoResDTO getExamineeInfo(int examId, int examineeId);
 
-  public boolean submitObjection(int examId, int examineeId, int questionId, String objectionComments);
+  public boolean submitObjection(int examId, int examineeId, int questionId,
+      String objectionComments);
 
-  public boolean submitObjectionReply(int examId, int examineeId, int questionId, String objectionReply);
+  public boolean submitObjectionReply(int examId, int examineeId, int questionId,
+      String objectionReply);
 
-  public List<Map<String , Object>> getQuestionsState(int examId, int examineeId);
+  public List<Map<String, Object>> getQuestionsState(int examId, int examineeId);
 
   public boolean updateQuestionScore(int resultId, int questionId, boolean isCorrected);
 
-  public boolean updateShortAnswerAndScore(int resultId, int questionId, boolean isCorrected ,String correctedAnswer, Integer partialScore);
+  public boolean updateShortAnswerAndScore(int resultId, int questionId, boolean isCorrected,
+      String correctedAnswer, Integer partialScore);
 
-  }
+}

--- a/src/main/java/com/nlb/service/ExamResultServiceImpl.java
+++ b/src/main/java/com/nlb/service/ExamResultServiceImpl.java
@@ -3,10 +3,10 @@ package com.nlb.service;
 
 import com.mongodb.client.result.UpdateResult;
 import com.nlb.dto.request.ExamResultReqDTO;
-import com.nlb.dto.response.ExamDataResDTO;
 import com.nlb.dto.response.ExamJoinResDTO;
 import com.nlb.dto.response.ExamResultCardDTO;
 import com.nlb.dto.response.ExamineeInfoResDTO;
+import com.nlb.dto.response.FullExamDataResDTO;
 import com.nlb.exception.BadRequestException;
 import com.nlb.exception.CustomAccessDeniedException;
 import com.nlb.exception.ErrorCode;
@@ -22,8 +22,10 @@ import com.nlb.vo.QuestionVO;
 import com.nlb.vo.ResultDetailVO;
 import java.net.URI;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -263,27 +265,61 @@ public class ExamResultServiceImpl implements ExamResultService {
 
   // 시험 문제 전체 + 답변 데이터 전체
   @Override
-  public ExamDataResDTO getExamData(int examId, int examineeId) {
+  public FullExamDataResDTO getExamData(int examId, int examineeId) {
     // 시험 문제 가져오기
     List<QuestionVO> questions = examService.getExamQuestions(examId);
 
-    // 응시자가 제출한 (몽고)데이터 가져오기
-    Map<String, Object> examResultData = getExamResultData(examId, examineeId);
+    // 응시자가 제출한 (몽고) 데이터 가져오기
+    Map<String, Object> examResultData = getExamResultDataAll(examId, examineeId);
+    System.out.println("examresultData 테스트 = " + examResultData);
 
+    // 시험 결과 ID 가져오기
     int resultId = examResultMapper.selectExamResultByExamIdandUser(examId, examineeId)
         .getResultId();
-    // 📌 빈 answers 최초 생성 지점 (추후 resultDetail 입력시 쓰임)
+
+    // 응시자가 제출한 답안 (없으면 빈 리스트)
     List<AnswerVO> answers = (List<AnswerVO>) examResultData.getOrDefault("answers",
         new ArrayList<>());
 
-    // 응답 DTO 구성
-    return new ExamDataResDTO(
+    // MongoDB에서 가져온 시험 메타데이터 사용
+    return new FullExamDataResDTO(
         examId,
+        (String) examResultData.getOrDefault("title", "제목 없음"),
+        (String) examResultData.getOrDefault("category", "카테고리 없음"),
+        ((Number) examResultData.getOrDefault("createrId", 0)).intValue(), //몽고DB타입과 호환성때문에 Number해봄
+        (String) examResultData.getOrDefault("entreeCode", ""),
+        ((Number) examResultData.getOrDefault("examTime", 0)).intValue(),
+        convertDateToLocalDateTime(examResultData.get("startedAt")),
+        convertDateToLocalDateTime(examResultData.get("finishedAt")),
+        ((Number) examResultData.getOrDefault("questionCount", 0)).intValue(),
         resultId,
         examineeId,
         questions,
         answers
     );
+
+  }
+
+  public Map<String, Object> getExamResultDataAll(int examId, int examineeId) {
+    // exam_result컬렉션에서 데이터 가져오기
+    Query queryResult = new Query(Criteria.where("examId").is(examId)
+        .and("examineeId").is(examineeId));
+    Map<String, Object> examResultData = mongoTemplate.findOne(queryResult, Map.class,
+        "exam_results");
+
+    // exam컬렉션에서 메타데이터 가져오기
+    Query queryExam = new Query(Criteria.where("examId").is(examId));
+    Map<String, Object> examMetaData = mongoTemplate.findOne(queryExam, Map.class, "exams");
+
+    if (examResultData == null) {
+      examResultData = new HashMap<>();
+    }
+    if (examMetaData != null) {
+      examResultData.putAll(examMetaData);
+    }
+    System.out.println("최종 examResultData: " + examResultData);
+
+    return examResultData;
   }
 
 
@@ -565,6 +601,13 @@ public class ExamResultServiceImpl implements ExamResultService {
     examResultMapper.updateExamTotalScore(params);
 
     return true;
+  }
+
+  private LocalDateTime convertDateToLocalDateTime(Object dateObj) {
+    if (dateObj instanceof Date) {
+      return ((Date) dateObj).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    }
+    return null; // 변환 실패 시 `null` 반환
   }
 
 

--- a/src/main/webapp/jsp/exam/create_exam.jsp
+++ b/src/main/webapp/jsp/exam/create_exam.jsp
@@ -407,6 +407,7 @@
         });
     }
 
+    // 문제 순서 변경 드래그 함수
     function enableDragAndDrop() {
         new Sortable(document.getElementById("question-list"), {
             animation: 150,

--- a/src/main/webapp/jsp/exam/take_exam.jsp
+++ b/src/main/webapp/jsp/exam/take_exam.jsp
@@ -1,0 +1,244 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+         pageEncoding="UTF-8"%>
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>시험 응시</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; font-family: Arial, sans-serif; }
+      body { display: flex; flex-direction: column; height: 100vh; }
+
+      .exam-header { display: flex; justify-content: space-between; padding: 15px; background: #007BFF; color: white; }
+      .exam-info { display: flex; gap: 20px; }
+      .timer { font-weight: bold; }
+
+      .exam-container { display: flex; flex: 1; }
+      .sidebar { width: 250px; background: #f4f4f4; padding: 20px; overflow-y: auto; }
+      .sidebar button { display: block; width: 100%; padding: 10px; margin: 5px 0; border: none; background: #ddd; cursor: pointer; text-align: left; }
+      .sidebar button:hover { background: #bbb; }
+      .content { flex: 1; padding: 20px; position: relative; }
+
+      .question-box { border: 1px solid #ccc; padding: 15px; margin-bottom: 15px; }
+      .question-content { font-size: 16px; font-weight: bold; margin-bottom: 10px; }
+      .options label { display: block; margin: 5px 0; }
+      .answer-input { width: 100%; padding: 8px; margin-top: 5px; border: 1px solid #ccc; }
+
+      .submit-btn { background: #28a745; color: white; padding: 10px; width: 200px; border: none; cursor: pointer; font-weight: bold; display: block; margin: 20px auto; }
+      .submit-btn:disabled { background: #aaa; cursor: not-allowed; }
+    </style>
+</head>
+<body>
+
+<!-- 헤더 -->
+<div class="exam-header">
+    <div class="exam-info">
+        <span>시험명: <strong id="exam-title"></strong></span>
+        <span>출제자: <strong id="exam-creator"></strong></span>
+        <span>총점: <strong id="total-score"></strong></span>
+        <span>카테고리: <strong id="exam-category"></strong></span>
+        <span>시간: <strong id="exam-time"></strong></span>
+    </div>
+    <div class="timer">
+        남은 시간: <strong id="remaining-time">00:00</strong>
+    </div>
+</div>
+
+<!-- 시험 본문 -->
+<div class="exam-container">
+    <!-- 문제 목록 -->
+    <div class="sidebar" id="question-list">
+        <h3>문제 목록</h3>
+    </div>
+
+    <!-- 문제 응시 폼 -->
+    <div class="content">
+        <div id="exam-questions"></div>
+        <button class="submit-btn" id="submit-exam" disabled>시험 제출</button>
+    </div>
+</div>
+
+<script>
+  var urlParams = new URLSearchParams(window.location.search);
+  var examId = urlParams.get("examId") || "44";
+
+  var questions = [];
+  var answers = {};
+  var remainingTime = 0;
+  var timerInterval;
+
+  function loadExamData() {
+    var url = "http://localhost:8082/api/exams/results/" + examId + "/exam-data";
+
+    console.log("시험 데이터 요청 URL:", url);
+
+    fetch(url)
+    .then(function(response) {
+      console.log("API 응답 상태 코드:", response.status);
+      if (!response.ok) {
+        throw new Error("서버 응답 오류: " + response.status);
+      }
+      return response.json();
+    })
+    .then(function(data) {
+      console.log("받은 시험 데이터:", data);
+      if (data.code == 200) {
+        renderExam(data.data);
+      } else {
+        alert("시험 데이터를 불러오는 중 오류 발생.");
+      }
+    })
+    .catch(function(error) {
+      console.error("시험 데이터 불러오기 실패:", error);
+    });
+  }
+
+  function getTotalScore(questions) {
+    return questions.reduce((total, question) => total + (question.pointsAllocation || 0), 0);
+  }
+
+  function renderExam(examData) {
+    console.log("렌더링할 시험 데이터:", examData);
+
+    if (!examData || !examData.questions || examData.questions.length === 0) {
+      console.error("시험 데이터가 없습니다!");
+      return;
+    }
+
+    // 제목, 카테고리, 출제자, 시간 추가
+    document.getElementById("exam-title").textContent = examData.title;
+    document.getElementById("exam-creator").textContent = "출제자: " + examData.createrId;
+    document.getElementById("total-score").textContent = getTotalScore(examData.questions);
+    document.getElementById("exam-category").textContent = "카테고리: " + examData.category;
+    document.getElementById("exam-time").textContent = "시간: " + examData.examTime + "분";
+
+    var questionList = document.getElementById("question-list");
+    var examQuestions = document.getElementById("exam-questions");
+
+    questionList.innerHTML = "<h3>문제 목록</h3>";
+    examQuestions.innerHTML = "";
+
+    for (var i = 0; i < examData.questions.length; i++) {
+      var q = examData.questions[i];
+
+      console.log("렌더링할 문제:", q);
+
+      var questionBtn = document.createElement("button");
+      questionBtn.textContent = "문제 " + (i + 1);
+      questionBtn.onclick = createScrollHandler(q.questionId);
+      questionList.appendChild(questionBtn);
+
+      var questionDiv = document.createElement("div");
+      questionDiv.className = "question-box";
+      questionDiv.id = "question-" + q.questionId;
+
+      var contentDiv = document.createElement("div");
+      contentDiv.className = "question-content";
+      contentDiv.textContent = (i + 1) + ". " + q.content + " (" + q.pointsAllocation + "점)";
+
+      questionDiv.appendChild(contentDiv);
+
+      var optionsDiv = document.createElement("div");
+      optionsDiv.className = "options";
+
+      if (q.type == "multiple_choice") {
+        renderMultipleChoiceOptions(q, optionsDiv);
+      } else {
+        renderShortAnswerInput(q, optionsDiv);
+      }
+
+      questionDiv.appendChild(optionsDiv);
+      examQuestions.appendChild(questionDiv);
+    }
+
+    // 시험 시간 설정
+    remainingTime = examData.examTime * 60;
+    startTimer();
+
+    document.getElementById("submit-exam").disabled = false;
+  }
+
+
+  function createScrollHandler(questionId) {
+    return function() {
+      var questionElement = document.getElementById("question-" + questionId);
+      if (questionElement) {
+        questionElement.scrollIntoView({ behavior: "smooth" });
+      }
+    };
+  }
+
+  function renderMultipleChoiceOptions(question, container) {
+    for (var i = 0; i < question.options.length; i++) {
+      var option = question.options[i];
+
+      var label = document.createElement("label");
+      var radio = document.createElement("input");
+      radio.type = "radio";
+      radio.name = "answer-" + question.questionId;
+      radio.value = option;
+      radio.onchange = createSaveAnswerHandler(question.questionId, option);
+
+      label.appendChild(radio);
+      label.appendChild(document.createTextNode(option));
+      container.appendChild(label);
+    }
+  }
+
+  function renderShortAnswerInput(question, container) {
+    var input = document.createElement("input");
+    input.type = "text";
+    input.className = "answer-input";
+    input.id = "answer-" + question.questionId;
+    input.oninput = createSaveAnswerHandler(question.questionId, input);
+
+    container.appendChild(input);
+  }
+
+  function createSaveAnswerHandler(questionId, value) {
+    return function() {
+      answers[questionId] = value;
+    };
+  }
+
+  function startTimer() {
+    updateTimerDisplay();
+    timerInterval = setInterval(function() {
+      remainingTime--;
+      updateTimerDisplay();
+
+      if (remainingTime <= 0) {
+        clearInterval(timerInterval);
+        alert("시험 시간이 종료되었습니다. 자동 제출합니다.");
+        submitExam();
+      }
+    }, 1000);
+  }
+
+  function updateTimerDisplay() {
+    var minutes = Math.floor(remainingTime / 60);
+    var seconds = remainingTime % 60;
+    document.getElementById("remaining-time").textContent =
+        (minutes < 10 ? "0" : "") + minutes + ":" + (seconds < 10 ? "0" : "") + seconds;
+  }
+
+  document.getElementById("submit-exam").addEventListener("click", submitExam);
+
+  loadExamData();
+
+  window.onload = function () {
+    console.log("페이지 로드 완료. 이벤트 등록 시작");
+    document.getElementById("submit-exam").addEventListener("click", submitExam);
+    loadExamData();
+  };
+
+  function submitExam() { //todo 마저 완성해야함
+    console.log("시험 제출 버튼 클릭됨.");
+  }
+
+
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
closed #88 
📣 **To Reviewers**
--- 
- 시험 응시 페이지 프론트 1차 구현 및 백엔드 연동
- 시험 입장 데이터 입력 후 API 요청 시 Join 으로 검증(RDB에 시험 첫 입장 등록) 후 응시페이지로 리다이렉트 + 시험지 데이터 불러온 후 렌더링
- 

- TODO
- 시험 입장처리 
- 남은 시간 관련 로직 
- 시험 시작 시간 활성화 시 동작 테스트
- 여러명 응시 상황 테스트
- 리다이렉트 사이에 응시자 신분 검증 관련 로직 가능
